### PR TITLE
Support merging resources

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -93,8 +93,8 @@ tasks:
           $map: {$eval: tests}
           each(test):
             taskId: {$eval: as_slugid(test.name)}
-            provisionerId: aws-provisioner-v1
-            workerType: github-worker
+            provisionerId: proj-taskcluster
+            workerType: ci
             created: {$fromNow: ''}
             deadline: {$fromNow: '60 minutes'}
             payload:

--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ The class has the following methods:
 * `resources.filter(pattern)` - return a new Resources object containing only resources matching the given regular expression string
 * `resources.map(functor)` - return a new Resources object, with fuctor applied to each resource.  This is typically used in modifiers.
 
+Resources must be unique -- tc-admin cannot manage multiple hooks with the same name, for example.
+However, some resource kinds support merging, where adding a resource with the same identity as one that already exists "merges" it into the existing resource.
+See the description of roles, below.
+
 The remaining classes represent individual resources.
 Each has an `id` formed from its kind and the unique identifier for the resource in the Taskcluster.
 For example, `Hook=release-hooks/beta-release`.
@@ -282,13 +286,26 @@ The items in `bindings` are instances of `Binding(exchange=.., routingKeyPattern
 ```python
 from tcadmin.resources import Role
 
-hook = Role(
+role = Role(
     roleId=..,
     description=..,
     scopes=(.., ..))
 ```
 
 As with hooks, `scopes` must be a tuple (not a list) of strings.
+
+Roles can be merged if their descriptions match.
+The resulting role contains the union of the scopes of the input roles.
+This functionality makes management of roles easier in cases where different parts of the generation process may add scopes to the same role.
+
+For example:
+
+```python
+resources.add(Role(roleId="my-role", description="My Role", scopes=["scope1"]))
+resources.add(Role(roleId="my-role", description="My Role", scopes=["scope2"]))
+```
+
+This will result in a single Role with scopes `["scope1", "scope2"]`.
 
 ### WorkerPool
 

--- a/tcadmin/resources/role.py
+++ b/tcadmin/resources/role.py
@@ -8,6 +8,7 @@ import attr
 
 from .resources import Resource
 from .util import description_converter, scopes_converter, list_formatter
+from ..util.scopes import normalizeScopes
 
 
 @attr.s
@@ -30,3 +31,12 @@ class Role(Resource):
     def to_api(self):
         "Construct a payload for use with auth.createRole or auth.updateRole"
         return {"description": self.description, "scopes": self.scopes}
+
+    def merge(self, other):
+        assert self.roleId == other.roleId
+        if self.description != other.description:
+            raise RuntimeError(
+                "Descriptions for {} to be merged differ".format(self.id)
+            )
+        scopes = normalizeScopes(self.scopes + other.scopes)
+        return Role(roleId=self.roleId, description=self.description, scopes=scopes)

--- a/tcadmin/util/scopes.py
+++ b/tcadmin/util/scopes.py
@@ -6,8 +6,6 @@
 
 import re
 
-from ..resources import Role
-
 
 class Resolver:
     """
@@ -23,6 +21,8 @@ class Resolver:
     def from_resources(cls, resources):
         """Construct an instance from a Resources instance, ignoring any non-Role
         resources"""
+        from ..resources import Role
+
         roles = {}
         for resource in resources:
             if isinstance(resource, Role):


### PR DESCRIPTION
At the moment, this just merges roles.  The functionality might be
useful for other resources, too, but that can be added later.

This is backward-compatible in that it changes specific subcases of an
error condition (duplicate resources) to a success condition (merged
resources).