### PR TITLE
use deleteWorkerPool to delete worker pools

### DIFF
--- a/tcadmin/update.py
+++ b/tcadmin/update.py
@@ -72,8 +72,8 @@ class Updater:
         except TaskclusterRestFailure as e:
             # A 409 Conflict error indicates this worker pool already exists,
             # and in most cases this means it's still in the process of being
-            # deleted (that is, has providerId = "null-provider" as set below in
-            # delete_workerpool).  In this case, we just update the worker pool
+            # deleted (that is, has providerId = "null-provider" as set by
+            # deleteWorkerPool).  In this case, we just update the worker pool
             # in-place.
             if e.status_code == 409:
                 return await self.update_workerpool(wp)
@@ -83,12 +83,7 @@ class Updater:
         await self.worker_manager.updateWorkerPool(wp.workerPoolId, wp.to_api())
 
     async def delete_workerpool(self, wp):
-        # worker-manager doesn't support deleting directly; instead we set the
-        # providerId to "null-provider".  Once the pool has no workers, the
-        # worker-manager will delete it.
-        as_api = wp.to_api()
-        as_api["providerId"] = "null-provider"
-        await self.worker_manager.updateWorkerPool(wp.workerPoolId, as_api)
+        await self.worker_manager.deleteWorkerPool(wp.workerPoolId)
 
     async def update_resource(self, verb, resource):
         msg = {


### PR DESCRIPTION
With this change, admins running this tool need not have
`worker-manager:provider:null-provider`.

See bug 1583928 and https://github.com/taskcluster/taskcluster/pull/1419.