### PR TITLE
Specify a semver compatibility range for TC client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     url="https://github.com/taskcluster/tc-admin",
     packages=find_packages("."),
     install_requires=[
-        "taskcluster~=21.3.0",
+        "taskcluster~=21.3",
         "click~=7.0",
         "blessings~=1.7",
         "attrs~=19.3.0",


### PR DESCRIPTION
The ~= operator's semantics are a bit surprising, and pins the minor version when given a three-segment argument.