### PR TITLE
Document client resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,23 @@ resources.add(Role(roleId="my-role", description="My Role", scopes=["scope2"]))
 
 This will result in a single Role with scopes `["scope1", "scope2"]`.
 
+### Client
+
+```python
+from tcadmin.resources import Client
+
+client = Client(
+    clientId=..,
+    description=..,
+    scopes=(.., ..))
+```
+
+Clients are managed and can be merged like roles.
+Any associated access tokens are not handled by this library,
+and should be reset with the `resetAccessToken` API after a client is created.
+
+Like roles, the clients managed here last "forever".
+
 ### WorkerPool
 
 ```python


### PR DESCRIPTION
I’d like to manage one for Servo with tc-admin. Since the README disclaims:

> *NOTE*: only functions described in this README are considered stable.
> Other functions defined by the library may change without notice.

… this PR adds `tcadmin.resources.Client` to APIs considered stable.

Hopefully this sounds acceptable. The API is the same as that `Role`, which is already considered stable.