### PR TITLE
Support Taskcluster Proxy

### DIFF
--- a/tcadmin/current/clients.py
+++ b/tcadmin/current/clients.py
@@ -5,10 +5,10 @@
 # obtain one at http://mozilla.org/MPL/2.0/.
 
 from taskcluster.aio import Auth
-from taskcluster import optionsFromEnvironment
 
 from ..resources import Client
 from ..util.sessions import aiohttp_session
+from ..util.taskcluster import optionsFromEnvironment
 
 
 async def fetch_clients(resources):

--- a/tcadmin/current/hooks.py
+++ b/tcadmin/current/hooks.py
@@ -5,10 +5,10 @@
 # obtain one at http://mozilla.org/MPL/2.0/.
 
 from taskcluster.aio import Hooks
-from taskcluster import optionsFromEnvironment
 
 from ..resources import Hook
 from ..util.sessions import aiohttp_session
+from ..util.taskcluster import optionsFromEnvironment
 
 
 async def fetch_hooks(resources):

--- a/tcadmin/current/roles.py
+++ b/tcadmin/current/roles.py
@@ -5,10 +5,10 @@
 # obtain one at http://mozilla.org/MPL/2.0/.
 
 from taskcluster.aio import Auth
-from taskcluster import optionsFromEnvironment
 
 from ..resources import Role
 from ..util.sessions import aiohttp_session
+from ..util.taskcluster import optionsFromEnvironment
 
 
 async def fetch_roles(resources):

--- a/tcadmin/current/secrets.py
+++ b/tcadmin/current/secrets.py
@@ -5,11 +5,11 @@
 # obtain one at http://mozilla.org/MPL/2.0/.
 
 from taskcluster.aio import Secrets
-from taskcluster import optionsFromEnvironment
 
 from ..options import with_options
 from ..resources import Secret
 from ..util.sessions import aiohttp_session
+from ..util.taskcluster import optionsFromEnvironment
 
 
 @with_options("with_secrets")

--- a/tcadmin/current/worker_pools.py
+++ b/tcadmin/current/worker_pools.py
@@ -5,10 +5,10 @@
 # obtain one at http://mozilla.org/MPL/2.0/.
 
 from taskcluster.aio import WorkerManager
-from taskcluster import optionsFromEnvironment
 
 from ..resources import WorkerPool
 from ..util.sessions import aiohttp_session
+from ..util.taskcluster import optionsFromEnvironment
 
 
 async def fetch_worker_pools(resources):

--- a/tcadmin/main.py
+++ b/tcadmin/main.py
@@ -109,10 +109,11 @@ def main(appconfig):
     @with_aiohttp_session
     async def applyCommand(**kwargs):
         "Apply the expected runtime configuration"
-        if not os.environ.get("TASKCLUSTER_CLIENT_ID"):
-            raise click.UsageError("TASKCLUSTER_CLIENT_ID must be set")
-        if not os.environ.get("TASKCLUSTER_ACCESS_TOKEN"):
-            raise click.UsageError("TASKCLUSTER_ACCESS_TOKEN must be set")
+        if not os.environ.get("TASKCLUSTER_PROXY_URL"):
+            if not os.environ.get("TASKCLUSTER_CLIENT_ID"):
+                raise click.UsageError("TASKCLUSTER_CLIENT_ID must be set")
+            if not os.environ.get("TASKCLUSTER_ACCESS_TOKEN"):
+                raise click.UsageError("TASKCLUSTER_ACCESS_TOKEN must be set")
 
         with AppConfig._as_current(appconfig):
             expected = await generate.resources()

--- a/tcadmin/tests/test_util_scopes.py
+++ b/tcadmin/tests/test_util_scopes.py
@@ -9,6 +9,7 @@ import taskcluster
 import os
 
 from tcadmin.util.scopes import Resolver, satisfies
+from tcadmin.util.taskcluster import optionsFromEnvironment
 from tcadmin.resources import Role, Resources
 
 
@@ -234,7 +235,7 @@ def auth():
             pytest.fail(msg)
         else:
             pytest.skip(msg)
-    return taskcluster.Auth(taskcluster.optionsFromEnvironment())
+    return taskcluster.Auth(optionsFromEnvironment())
 
 
 @pytest.fixture(scope="module")

--- a/tcadmin/update.py
+++ b/tcadmin/update.py
@@ -8,9 +8,10 @@ import blessings
 
 from .util.ansi import strip_ansi
 from .util.sessions import aiohttp_session
+from .util.taskcluster import optionsFromEnvironment
 
 from taskcluster.aio import Auth, Hooks, WorkerManager, Secrets
-from taskcluster import optionsFromEnvironment, TaskclusterRestFailure
+from taskcluster import TaskclusterRestFailure
 
 t = blessings.Terminal()
 

--- a/tcadmin/util/taskcluster.py
+++ b/tcadmin/util/taskcluster.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+from taskcluster import optionsFromEnvironment as originalOptions
+import os
+
+
+def optionsFromEnvironment():
+    """Build Taskcluster options, supporting proxy"""
+    if "TASKCLUSTER_PROXY_URL" in os.environ:
+        return {
+            "rootUrl": os.environ["TASKCLUSTER_PROXY_URL"],
+        }
+    else:
+        return originalOptions()


### PR DESCRIPTION
This is needed to run `tc-admin apply` from a taskcluster task using the taskcluster proxy to authenticate the client.

Here is a [current task](https://community-tc.services.mozilla.com/tasks/EdVYOnaQQnSgd9DaRx2rtw) that fails due to lack of proxy support (no credentials are available)

I've tested that code in [a sample task](https://community-tc.services.mozilla.com/tasks/dsoPQTibRc-tAenaGdnPgg/runs/0/logs/live/https%3A%2F%2Fcommunity-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FdsoPQTibRc-tAenaGdnPgg%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log) with proxy enabled, against a dummy [tc-admin.py](https://gist.github.com/La0/d4d5ae8facfeee9e35eade65b4bed7a5) managing a *secret*.