### PR TITLE
Pin dependencies in setup.py

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "pinDependencies"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Hopefully this will pin setup.py versions just like those in requirements.txt, at least pinning the *direct* dependencies of tc-admin.  This is useful since tc-admin is installed by users like https://github.com/mozilla/community-tc-config/ as a library, thus ignoring our requirements.txt.