### PR TITLE
Add support for customizing root URL in tc-admin.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,32 @@ appconfig.description_prefix = "YOUR_CUSTOM_PREFIX"
 
 The DEFAULT value of the description_prefix is `*DO NOT EDIT* - This resource is configured automatically.\n\n`
 
+### Root URL
+
+For the common case of a configuration that applies to only one Taskcluster deployment, specify that deployment's root URL in `tc-admin.py`:
+
+```python
+from tcadmin.appconfig import AppConfig
+
+appconfig = AppConfig()
+appconfig.root_url = "https://taskcluster.example.com"
+```
+
+To support more complex cases, this value can also be an async callable.
+It will be invoked once, after the `click` options have been processed, so it can access `appconfig.options` if necessary.
+
+The current root URL is available from an async helper function:
+
+```python
+from tcadmin.util.root_url import root_url
+
+async def foo():
+    print(await root_url())
+```
+
+This will retrieve the value from the AppConfig or, if that is not set, from `TASKCLUSTER_ROOT_URL`.
+If both are set, and the values do not match, it will produce an error message.
+
 ### Loading Config Sources
 
 Most uses of this library load configuration data from some easily-modified YAML files.
@@ -512,18 +538,6 @@ assert ml.matches("foo")
 ```
 
 This functionality is used to track managed resources, but may be useful otherwise.
-
-### Root URL
-
-The current root_url is available from a short helper function:
-
-```python
-from tcadmin.util.root_url import root_url
-
-print(root_url())
-```
-
-This does little more than retrieve the value from `os.environ`, but is a little less verbose.
 
 # Development
 

--- a/tcadmin/appconfig.py
+++ b/tcadmin/appconfig.py
@@ -107,6 +107,9 @@ class AppConfig:
         default="*DO NOT EDIT* - This resource is configured automatically.\n\n",
     )
 
+    # The root URL for the deployment, or an async callable to return it.
+    root_url = attr.ib(type=str, init=False, default=None)
+
     # Command-line options for the resource-generation process
     options = attr.ib(init=False, factory=lambda: OptionsRegistry("options"))
 

--- a/tcadmin/main.py
+++ b/tcadmin/main.py
@@ -38,15 +38,14 @@ def main(appconfig):
     def cmd():
         """Manage Taskcluster configuration.
 
-        The environment variable TASKCLUSTER_ROOT_URL must be set for all
-        invocations of this command, giving the Taskcluster deployment against
-        which it is run.
+        The root URL for the Taskcluster deployment against which to run is
+        given either in `tc-admin.py` or via the environment variable
+        TASKCLUSTER_ROOT_URL.
 
         For `tcadmin apply`, TASKCLUSTER_CLIENT_ID and TASKCLUSTER_ACCESS_TOKEN
         must also be supplied.
         """
-        if not os.environ.get("TASKCLUSTER_ROOT_URL"):
-            raise click.UsageError("TASKCLUSTER_ROOT_URL must be set")
+        pass
 
     @cmd.command(name="generate")
     @options.generate_options.apply

--- a/tcadmin/tests/test_util_root_url.py
+++ b/tcadmin/tests/test_util_root_url.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+import click
+
+from tcadmin.util import root_url as root_url_mod
+
+
+@pytest.fixture
+def root_url():
+    # clear the memoization
+    root_url_mod._root_url = None
+    return root_url_mod.root_url
+
+
+@pytest.mark.asyncio
+async def test_root_url_from_env(appconfig, root_url, monkeypatch):
+    monkeypatch.setenv("TASKCLUSTER_ROOT_URL", "https://tc-testing.example.com")
+    assert await root_url() == "https://tc-testing.example.com"
+
+
+@pytest.mark.asyncio
+async def test_root_url_not_set(appconfig, root_url, monkeypatch):
+    monkeypatch.delenv("TASKCLUSTER_ROOT_URL", raising=False)
+    with pytest.raises(click.UsageError):
+        await root_url()
+
+
+@pytest.mark.asyncio
+async def test_root_url_from_appconfig_str(appconfig, root_url, monkeypatch):
+    monkeypatch.delenv("TASKCLUSTER_ROOT_URL", raising=False)
+    appconfig.root_url = "https://tc-testing.example.com"
+    assert await root_url() == "https://tc-testing.example.com"
+
+
+@pytest.mark.asyncio
+async def test_root_url_from_appconfig_fn(appconfig, root_url, monkeypatch):
+    monkeypatch.delenv("TASKCLUSTER_ROOT_URL", raising=False)
+
+    async def get_root():
+        return "https://tc-testing.example.com"
+
+    appconfig.root_url = get_root
+    assert await root_url() == "https://tc-testing.example.com"
+
+
+@pytest.mark.asyncio
+async def test_root_url_from_appconfig_diferent(appconfig, root_url, monkeypatch):
+    monkeypatch.setenv("TASKCLUSTER_ROOT_URL", "https://tc-testing.example.com")
+    appconfig.root_url = "https://something-else.example.com"
+    with pytest.raises(click.UsageError):
+        await root_url()

--- a/tcadmin/util/root_url.py
+++ b/tcadmin/util/root_url.py
@@ -5,8 +5,31 @@
 # obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
+import click
+
+from ..appconfig import AppConfig
 
 
-def root_url():
+_root_url = None
+
+
+async def root_url():
     """Helper function to get the root URL"""
-    return os.environ["TASKCLUSTER_ROOT_URL"]
+    global _root_url
+    if _root_url:
+        return _root_url
+
+    appconfig = AppConfig.current()
+    if appconfig.root_url:
+        root_url = appconfig.root_url
+        if callable(root_url):
+            root_url = await appconfig.root_url()
+        if "TASKCLUSTER_ROOT_URL" in os.environ:
+            if os.environ["TASKCLUSTER_ROOT_URL"] != root_url:
+                raise click.UsageError(f"TASKCLUSTER_ROOT_URL does not match {root_url}")
+        _root_url = root_url
+    else:
+        if "TASKCLUSTER_ROOT_URL" not in os.environ:
+            raise click.UsageError("TASKCLUSTER_ROOT_URL must be set")
+        _root_url = os.environ["TASKCLUSTER_ROOT_URL"]
+    return _root_url


### PR DESCRIPTION
This will support both the simple, common case of a single default root
URL, and more complex cases involving async operations and
command-line-option-based determination of the appropriate root URL.