### PR TITLE
Use `root_url()` to determine root URL for all TC clients

### DIFF
--- a/tcadmin/apply.py
+++ b/tcadmin/apply.py
@@ -31,5 +31,5 @@ async def apply_changes(generated, current, grep):
             resources=(r for r in current.resources if reg.search(r.id)),
         )
 
-    updater = Updater()
+    updater = await Updater()
     await updater.update(generated, current)

--- a/tcadmin/current/clients.py
+++ b/tcadmin/current/clients.py
@@ -8,11 +8,11 @@ from taskcluster.aio import Auth
 
 from ..resources import Client
 from ..util.sessions import aiohttp_session
-from ..util.taskcluster import optionsFromEnvironment
+from ..util.taskcluster import tcClientOptions
 
 
 async def fetch_clients(resources):
-    auth = Auth(optionsFromEnvironment(), session=aiohttp_session())
+    auth = Auth(await tcClientOptions(), session=aiohttp_session())
     query = {}
     while True:
         res = await auth.listClients(query=query)

--- a/tcadmin/current/hooks.py
+++ b/tcadmin/current/hooks.py
@@ -8,11 +8,11 @@ from taskcluster.aio import Hooks
 
 from ..resources import Hook
 from ..util.sessions import aiohttp_session
-from ..util.taskcluster import optionsFromEnvironment
+from ..util.taskcluster import tcClientOptions
 
 
 async def fetch_hooks(resources):
-    hooks = Hooks(optionsFromEnvironment(), session=aiohttp_session())
+    hooks = Hooks(await tcClientOptions(), session=aiohttp_session())
     for hookGroupId in (await hooks.listHookGroups())["groups"]:
         idPrefix = "Hook={}/".format(hookGroupId)
         # if no hook with this hookGroupId is managed, skip it

--- a/tcadmin/current/roles.py
+++ b/tcadmin/current/roles.py
@@ -8,11 +8,11 @@ from taskcluster.aio import Auth
 
 from ..resources import Role
 from ..util.sessions import aiohttp_session
-from ..util.taskcluster import optionsFromEnvironment
+from ..util.taskcluster import tcClientOptions
 
 
 async def fetch_roles(resources):
-    auth = Auth(optionsFromEnvironment(), session=aiohttp_session())
+    auth = Auth(await tcClientOptions(), session=aiohttp_session())
     for role in await auth.listRoles():
         role = Role.from_api(role)
         if resources.is_managed(role.id):

--- a/tcadmin/current/secrets.py
+++ b/tcadmin/current/secrets.py
@@ -9,12 +9,12 @@ from taskcluster.aio import Secrets
 from ..options import with_options
 from ..resources import Secret
 from ..util.sessions import aiohttp_session
-from ..util.taskcluster import optionsFromEnvironment
+from ..util.taskcluster import tcClientOptions
 
 
 @with_options("with_secrets")
 async def fetch_secrets(resources, with_secrets):
-    api = Secrets(optionsFromEnvironment(), session=aiohttp_session())
+    api = Secrets(await tcClientOptions(), session=aiohttp_session())
     query = {}
     while True:
         res = await api.list(query=query)

--- a/tcadmin/current/worker_pools.py
+++ b/tcadmin/current/worker_pools.py
@@ -8,11 +8,11 @@ from taskcluster.aio import WorkerManager
 
 from ..resources import WorkerPool
 from ..util.sessions import aiohttp_session
-from ..util.taskcluster import optionsFromEnvironment
+from ..util.taskcluster import tcClientOptions
 
 
 async def fetch_worker_pools(resources):
-    worker_manager = WorkerManager(optionsFromEnvironment(), session=aiohttp_session())
+    worker_manager = WorkerManager(await tcClientOptions(), session=aiohttp_session())
     query = {}
     while True:
         res = await worker_manager.listWorkerPools(query=query)

--- a/tcadmin/tests/conftest.py
+++ b/tcadmin/tests/conftest.py
@@ -31,3 +31,12 @@ def appconfig():
     appconfig = AppConfig()
     with AppConfig._as_current(appconfig):
         yield appconfig
+
+
+@pytest.fixture(scope="module")
+def fake_root_url():
+    import tcadmin.util.root_url
+    fake_root_url = "https://tc-testing.example.com"
+    tcadmin.util.root_url._root_url = fake_root_url
+    yield fake_root_url
+    tcadmin.util.root_url._root_url = None

--- a/tcadmin/tests/test_current_clients.py
+++ b/tcadmin/tests/test_current_clients.py
@@ -10,7 +10,7 @@ from tcadmin.resources import Resources, Client
 from tcadmin.current.clients import fetch_clients
 
 
-pytestmark = pytest.mark.usefixtures("appconfig")
+pytestmark = pytest.mark.usefixtures("appconfig", "fake_root_url")
 
 
 @pytest.fixture

--- a/tcadmin/tests/test_current_hooks.py
+++ b/tcadmin/tests/test_current_hooks.py
@@ -10,7 +10,7 @@ from tcadmin.resources import Resources, Hook
 from tcadmin.current.hooks import fetch_hooks
 
 
-pytestmark = pytest.mark.usefixtures("appconfig")
+pytestmark = pytest.mark.usefixtures("appconfig", "fake_root_url")
 
 
 @pytest.fixture

--- a/tcadmin/tests/test_current_roles.py
+++ b/tcadmin/tests/test_current_roles.py
@@ -10,7 +10,7 @@ from tcadmin.resources import Resources, Role
 from tcadmin.current.roles import fetch_roles
 
 
-pytestmark = pytest.mark.usefixtures("appconfig")
+pytestmark = pytest.mark.usefixtures("appconfig", "fake_root_url")
 
 
 @pytest.fixture

--- a/tcadmin/tests/test_current_secrets.py
+++ b/tcadmin/tests/test_current_secrets.py
@@ -11,6 +11,9 @@ from tcadmin.resources import Resources, Secret
 from tcadmin.current.secrets import fetch_secrets
 
 
+pytestmark = pytest.mark.usefixtures("fake_root_url")
+
+
 @pytest.fixture
 def Secrets(mocker):
     """

--- a/tcadmin/tests/test_current_worker_pools.py
+++ b/tcadmin/tests/test_current_worker_pools.py
@@ -10,7 +10,7 @@ from tcadmin.resources import Resources
 from tcadmin.current.worker_pools import fetch_worker_pools
 
 
-pytestmark = pytest.mark.usefixtures("appconfig")
+pytestmark = pytest.mark.usefixtures("appconfig", "fake_root_url")
 
 
 @pytest.fixture

--- a/tcadmin/tests/test_util_scopes.py
+++ b/tcadmin/tests/test_util_scopes.py
@@ -9,7 +9,6 @@ import taskcluster
 import os
 
 from tcadmin.util.scopes import Resolver, satisfies
-from tcadmin.util.taskcluster import optionsFromEnvironment
 from tcadmin.resources import Role, Resources
 
 
@@ -238,7 +237,8 @@ def auth():
             pytest.fail(msg)
         else:
             pytest.skip(msg)
-    return taskcluster.Auth(optionsFromEnvironment())
+        return
+    return taskcluster.Auth({"rootUrl": os.environ["TASKCLUSTER_ROOT_URL"]})
 
 
 @pytest.fixture(scope="module")

--- a/tcadmin/update.py
+++ b/tcadmin/update.py
@@ -9,7 +9,7 @@ import blessings
 from .appconfig import AppConfig
 from .util.ansi import strip_ansi
 from .util.sessions import aiohttp_session
-from .util.taskcluster import optionsFromEnvironment
+from .util.taskcluster import tcClientOptions
 from .constants import (
     ACTION_CREATE,
     ACTION_UPDATE,
@@ -29,12 +29,12 @@ class Updater:
     A simple one-instance class to encapsulate shared Taskcluster API clients.
     """
 
-    def __init__(self):
-        self.auth = Auth(optionsFromEnvironment(), session=aiohttp_session())
-        self.secrets = Secrets(optionsFromEnvironment(), session=aiohttp_session())
-        self.hooks = Hooks(optionsFromEnvironment(), session=aiohttp_session())
+    async def __init__(self):
+        self.auth = Auth(await tcClientOptions(), session=aiohttp_session())
+        self.secrets = Secrets(await tcClientOptions(), session=aiohttp_session())
+        self.hooks = Hooks(await tcClientOptions(), session=aiohttp_session())
         self.worker_manager = WorkerManager(
-            optionsFromEnvironment(), session=aiohttp_session()
+            await tcClientOptions(), session=aiohttp_session()
         )
 
     async def create_role(self, role):

--- a/tcadmin/util/taskcluster.py
+++ b/tcadmin/util/taskcluster.py
@@ -4,13 +4,18 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 
-from taskcluster import optionsFromEnvironment as originalOptions
+from taskcluster import optionsFromEnvironment
 import os
 
+from .root_url import root_url
 
-def optionsFromEnvironment():
-    """Build Taskcluster options, supporting proxy"""
+
+async def tcClientOptions():
+    """Build Taskcluster client options, supporting proxy and getting root_url
+    from the appconfig"""
     if "TASKCLUSTER_PROXY_URL" in os.environ:
         return {"rootUrl": os.environ["TASKCLUSTER_PROXY_URL"]}
     else:
-        return originalOptions()
+        options = optionsFromEnvironment()
+        options["rootUrl"] = await root_url()
+        return options


### PR DESCRIPTION
Without this, `appconfig.root_url = ..` doesn't really help much!

Also, I released #177 as v2.7.0, but (a) it didn't work due to this bug and (b) changing `root_url` to be async is a breaking change, so that should have been v3.0.0.  I've since yanked v2.7.0, and on merging this PR will release 3.0.0.