### PR TITLE
Speed up diff

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         "aiohttp~=3.7.0",
         "pytest~=6.2.0",
         "pyyaml~=5.4",
-        "patiencediff==0.2.2",
     ],
     setup_requires=["pytest-runner", "flake8"],
     tests_require=["pytest", "pytest-mock", "pytest-asyncio~=0.14.0", "flake8", "asyncmock"],


### PR DESCRIPTION
In the firefoxci cluster, we're seeing diff runs of >5 minutes
regularly, and >15 min when there are many many changes. This puts a lot
of friction on rolling out urgent fixes: since Jenkins diffs, then
applies to stage, then diffs, then applies to firefoxci, an urgent
rollout can take upwards of 40 minutes where it took less than 5 before.

Fixes #192