### PR TITLE
Cleanup temporary files from fast diff

### DIFF
--- a/tcadmin/diff.py
+++ b/tcadmin/diff.py
@@ -8,8 +8,8 @@ import re
 import click
 import blessings
 import attr
-import tempfile
 import subprocess
+from tempfile import NamedTemporaryFile
 
 from .util.ansi import strip_ansi
 from .resources import Resources
@@ -19,25 +19,24 @@ t = blessings.Terminal()
 
 
 def fast_diff(left, right, n):
-    left_file = tempfile.NamedTemporaryFile("w")
-    left_file.write("\n".join(left))
-    right_file = tempfile.NamedTemporaryFile("w")
-    right_file.write("\n".join(right))
-    output = subprocess.run(
-        [
-            "diff",
-            f"-U{n}",
-            "--label",
-            "current",
-            "--label",
-            "generated",
-            left_file.name,
-            right_file.name,
-        ],
-        encoding="utf8",
-        stdout=subprocess.PIPE,
-    ).stdout
-    return output.split("\n")
+    with NamedTemporaryFile("w") as left_file, NamedTemporaryFile("w") as right_file:
+        left_file.write("\n".join(left))
+        right_file.write("\n".join(right))
+        output = subprocess.run(
+            [
+                "diff",
+                f"-U{n}",
+                "--label",
+                "current",
+                "--label",
+                "generated",
+                left_file.name,
+                right_file.name,
+            ],
+            encoding="utf8",
+            stdout=subprocess.PIPE,
+        ).stdout
+        return output.split("\n")
 
 
 diff_options.add(


### PR DESCRIPTION
Follow-on for PR #195 - Use a context manager so that temporary files are cleaned up at the end of execution.

I verified this locally by changing the code to print the names of the temporary files, installing the code for community-tc-admin, running a diff, and then checking that the temp files were not present. There were a lot of other temp files - other processes are not as clean!
