### PR TITLE
diff: support unknown starting characters when colouring diff

### DIFF
--- a/tcadmin/diff.py
+++ b/tcadmin/diff.py
@@ -9,6 +9,7 @@ import click
 import blessings
 import attr
 import subprocess
+from collections import defaultdict
 from tempfile import NamedTemporaryFile
 
 from .util.ansi import strip_ansi
@@ -118,11 +119,11 @@ def textual_diff(generated, current, context):
         return ""
 
     lines = fast_diff(left, right, context)
+    colors = defaultdict(lambda: lambda s: s)
     colors = {
         "-": lambda s: t.red(strip_ansi(s)),
         "+": lambda s: t.green(strip_ansi(s)),
         "@": lambda s: t.yellow(strip_ansi(s)) + " " + contextualize(s),
-        " ": lambda s: s,
     }
     # colorize the lines
     lines = (


### PR DESCRIPTION
We switched to relying on the system diff late last year, but this also
means we shouldn't make assumptions about what characters the diff lines
can start with.

For example, sometimes the diff output has a `\\ No newline at end of
file` in it (for some reason). When this happens an exception is raised
because `\\` is not a valid key in the 'colors' dictionary.

This turns 'colors' into a `defaultdict` so any lines that start with
unrecognized characters will simply be passed through uncoloured.

Fixes #204