### PR TITLE
Fix git clone issue

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -23,7 +23,7 @@ tasks:
       else:
         $if: 'tasks_for == "github-pull-request"'
         then:
-          git_url: ${event.pull_request.head.repo.git_url}
+          git_url: ${event.pull_request.head.repo.clone_url}
           url: ${event.pull_request.head.repo.url}
           ref: ${event.pull_request.head.sha}
         else:


### PR DESCRIPTION
@ahal saw this issue in https://github.com/taskcluster/tc-admin/pull/207

```
[taskcluster 2022-05-12 18:22:02.451Z] === Task Starting ===
Cloning into 'repo'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
```