### PR TITLE
Pre cmd checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .release/
 dist/
 pip-wheel-metadata/
+.python-version


### PR DESCRIPTION
Background: we want to make sure that our ci-config clone is up-to-date before we run `tc-admin apply`.
(I didn't add the up-to-date check in tc-admin because it's mercurial- and hg.m.o- specific; that code is [here](https://phabricator.services.mozilla.com/D151654).)