### PR TITLE
Fix textual diff

### DIFF
--- a/tcadmin/diff.py
+++ b/tcadmin/diff.py
@@ -120,11 +120,11 @@ def textual_diff(generated, current, context):
 
     lines = fast_diff(left, right, context)
     colors = defaultdict(lambda: lambda s: s)
-    colors = {
+    colors.update({
         "-": lambda s: t.red(strip_ansi(s)),
         "+": lambda s: t.green(strip_ansi(s)),
         "@": lambda s: t.yellow(strip_ansi(s)) + " " + contextualize(s),
-    }
+    })
     # colorize the lines
     lines = (
         colors[l[0]](l).rstrip() for l in (line if line else " " for line in lines)


### PR DESCRIPTION
Commit 47fa559132d6b03817fecc2e231e87e5c7ec9051 tried to fix missing `\` in the `colors` dict, but had a typo.