### PR TITLE
Force flush temp files before diffing them in `tc-admin diff`

### DIFF
--- a/tcadmin/diff.py
+++ b/tcadmin/diff.py
@@ -22,7 +22,11 @@ t = blessings.Terminal()
 def fast_diff(left, right, n):
     with NamedTemporaryFile("w") as left_file, NamedTemporaryFile("w") as right_file:
         left_file.write("\n".join(left))
+        left_file.flush()
+
         right_file.write("\n".join(right))
+        right_file.flush()
+
         output = subprocess.run(
             [
                 "diff",


### PR DESCRIPTION
I've had an issue where `tc-admin diff` would always return an empty diff. After some investigation, it turns out that by the time the `diff` command is ran, both files were still empty.

I couldn't find any python change that would explain why this would've broken when I know it used to work 2 years ago.