### PR TITLE
fix: output resources as real yaml

### DIFF
--- a/tcadmin/output.py
+++ b/tcadmin/output.py
@@ -9,17 +9,17 @@ import click
 from .options import with_options, output_options
 
 
-output_options.add(click.option("--text/--json", default=True, help="output format"))
+output_options.add(click.option("--yaml/--json", default=True, help="output format"))
 output_options.add(
     click.option("--grep", help="regular expression limiting resources displayed")
 )
 
 
-@with_options("text", "grep")
-def display_resources(resources, text, grep):
+@with_options("yaml", "grep")
+def display_resources(resources, yaml, grep):
     if grep:
         resources = resources.filter(grep)
-    if text:
-        print(resources)
+    if yaml:
+        print(resources.to_yaml())
     else:
-        print(repr(resources))
+        print(resources.to_json())

--- a/tcadmin/resources/resources.py
+++ b/tcadmin/resources/resources.py
@@ -13,6 +13,7 @@ from sortedcontainers import SortedKeyList
 
 from ..util.matchlist import MatchList
 from ..util.json import pretty_json
+from ..util.yaml import pretty_yaml
 
 t = blessings.Terminal()
 
@@ -47,6 +48,9 @@ class Resource(object):
         d = attr.asdict(self)
         d["kind"] = self.kind
         return d
+
+    def to_yaml(self):
+        return self.to_json()
 
     def to_api(self):
         "Construct a payload for Taskcluster API methods"
@@ -181,19 +185,17 @@ class Resources:
         return self.resources.__iter__()
 
     def __str__(self):
-        self._verify()
-        return "managed:\n{}\n\nresources:\n{}".format(
-            "\n".join("  - " + m for m in self.managed),
-            textwrap.indent("\n\n".join(str(r) for r in self), "  "),
-        )
+        return self.to_yaml()
 
-    def __repr__(self):
-        return pretty_json(self.to_json())
+    def to_yaml(self):
+        "Convert to a YAML data structure"
+        self._verify()
+        return pretty_yaml({"resources": [r.to_yaml() for r in self], "managed": list(self.managed)})
 
     def to_json(self):
         "Convert to a JSON-able data structure"
         self._verify()
-        return {"resources": [r.to_json() for r in self], "managed": list(self.managed)}
+        return pretty_json({"resources": [r.to_json() for r in self], "managed": list(self.managed)})
 
     @classmethod
     def from_json(cls, json):

--- a/tcadmin/util/yaml.py
+++ b/tcadmin/util/yaml.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+import yaml
+
+
+def pretty_yaml(value):
+    return yaml.dump(value)


### PR DESCRIPTION
At the moment resources are printed in a yaml looking structure that is usually not valid yaml. This change fixes that, and uses a proper yaml dumper to ensure output is parseable. I've also:
- Updated the output options to be either yaml or json (there's no point in this yaml-like 'text' format when real yaml is available)
- Removed the `repr` for Resources that returns json in favour of using explicit calls to `to_json` insetad. (I've kept the `__str__` overload outputting yaml because that felt sensible.)