### PR TITLE
diff: exit 2 in case we find differences

### DIFF
--- a/tcadmin/main.py
+++ b/tcadmin/main.py
@@ -106,7 +106,7 @@ def main(appconfig):
             actual = await current.resources(expected.managed)
             different = diff.show_diff(expected, actual)
             if different:
-                sys.exit(1)
+                sys.exit(2)
 
     @cmd.command(name="check")
     @options.generate_options.apply


### PR DESCRIPTION
There's currently no way for consumers to differentiate between "there was an error generating the diff" and "there were differences", since both exit 1.

Unfortunately this is reversed from the diff command, which exits "0 if the inputs are the same, 1 if different, 2 if trouble", but given python's behavior I'm not sure we can reliably do better.