### PR TITLE
Fixes AWS launch config sorting

### DIFF
--- a/tcadmin/resources/worker_pool.py
+++ b/tcadmin/resources/worker_pool.py
@@ -32,6 +32,8 @@ class WorkerPool(Resource):
                 return lc["zone"]  # gcp
             if "location" in lc:
                 return lc["location"]  # azure
+            if "region" in lc:
+                return lc["region"]  # aws
 
         if "launchConfigs" in config:
             config["launchConfigs"].sort(key=sort_key)


### PR DESCRIPTION
This fixes this error we saw while generating community-tc config:

```
  File "venv/lib/python3.13/site-packages/tcadmin/resources/worker_pool.py", line 38, in _sort_launch_configs
    config["launchConfigs"].sort(key=sort_key)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'
```