### PR TITLE
Ensure descriptions include prefix

### DIFF
--- a/tcadmin/resources/client.py
+++ b/tcadmin/resources/client.py
@@ -30,10 +30,10 @@ class Client(Resource):
     @classmethod
     def from_api(cls, api_result):
         "Construct a new instance from the result of a taskcluster API call"
-        return cls(
+        return cls._construct_without_converters(
             clientId=api_result["clientId"],
             description=api_result["description"],
-            scopes=api_result["scopes"],
+            scopes=scopes_converter(api_result["scopes"]),
         )
 
     def to_api(self):

--- a/tcadmin/resources/hook.py
+++ b/tcadmin/resources/hook.py
@@ -68,7 +68,7 @@ class Hook(Resource):
     @classmethod
     def from_api(cls, api_result):
         "Construct a new instance from the result of a taskcluster API call"
-        return cls(
+        return cls._construct_without_converters(
             hookId=api_result["hookId"],
             hookGroupId=api_result["hookGroupId"],
             # flatten the metadata sub-key
@@ -76,8 +76,10 @@ class Hook(Resource):
             name=api_result["metadata"]["name"],
             owner=api_result["metadata"]["owner"],
             emailOnError=api_result["metadata"]["emailOnError"],
-            schedule=api_result["schedule"],
-            bindings=tuple(Binding.from_api(b) for b in api_result["bindings"]),
+            schedule=schedule_converter(api_result["schedule"]),
+            bindings=bindings_converter(
+                tuple(Binding.from_api(b) for b in api_result["bindings"])
+            ),
             task=api_result["task"],
             triggerSchema=api_result["triggerSchema"],
         )

--- a/tcadmin/resources/resources.py
+++ b/tcadmin/resources/resources.py
@@ -42,6 +42,37 @@ class Resource(object):
         kind = json.pop("kind")
         return cls._kind_classes()[kind](**json)
 
+    @classmethod
+    def _construct_without_converters(cls, **kwargs):
+        """
+        Build an instance of ``cls`` without running attrs field converters.
+
+        Used by ``from_api`` to keep live-API values verbatim. Validators and
+        ``__attrs_post_init__`` still run; defaults are honoured for any
+        field not present in ``kwargs``.
+        """
+        obj = cls.__new__(cls)
+        for field in attr.fields(cls):
+            if field.name in kwargs:
+                value = kwargs[field.name]
+            elif field.default is not attr.NOTHING:
+                if isinstance(field.default, attr.Factory):
+                    value = field.default.factory()
+                else:
+                    value = field.default
+            else:
+                raise TypeError(
+                    "{}._construct_without_converters() missing required "
+                    "field: {}".format(cls.__name__, field.name)
+                )
+            object.__setattr__(obj, field.name, value)
+        for field in attr.fields(cls):
+            if field.validator is not None:
+                field.validator(obj, field, getattr(obj, field.name))
+        if hasattr(obj, "__attrs_post_init__"):
+            obj.__attrs_post_init__()
+        return obj
+
     def to_json(self):
         "Return a JSON-able version of this object, including a `kind` property"
         d = attr.asdict(self)

--- a/tcadmin/resources/role.py
+++ b/tcadmin/resources/role.py
@@ -22,10 +22,10 @@ class Role(Resource):
     @classmethod
     def from_api(cls, api_result):
         "Construct a new instance from the result of a taskcluster API call"
-        return cls(
+        return cls._construct_without_converters(
             roleId=api_result["roleId"],
             description=api_result["description"],
-            scopes=api_result["scopes"],
+            scopes=scopes_converter(api_result["scopes"]),
         )
 
     def to_api(self):

--- a/tcadmin/resources/secret.py
+++ b/tcadmin/resources/secret.py
@@ -62,7 +62,12 @@ class Secret(Resource):
     @classmethod
     def from_api(cls, name, api_result=None):
         "Construct a new instance from the result of a taskcluster API call"
-        return cls(name=name, secret=api_result["secret"] if api_result else NoSecret)
+        # Use the no-converter constructor for consistency with other Resource
+        # subclasses, even though Secret has no field-level converters today.
+        return cls._construct_without_converters(
+            name=name,
+            secret=api_result["secret"] if api_result else NoSecret,
+        )
 
     def to_api(self):
         "Construct a payload for use with secrets.set"

--- a/tcadmin/resources/worker_pool.py
+++ b/tcadmin/resources/worker_pool.py
@@ -44,8 +44,7 @@ class WorkerPool(Resource):
     @classmethod
     def from_api(cls, api_result):
         "Construct a new instance from the result of a taskcluster API call"
-
-        return cls(
+        return cls._construct_without_converters(
             workerPoolId=api_result["workerPoolId"],
             description=api_result["description"],
             owner=api_result["owner"],

--- a/tcadmin/tests/test_from_api_raw.py
+++ b/tcadmin/tests/test_from_api_raw.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Tests for ``Resource.from_api``: live-API descriptions are preserved
+verbatim (the ``*DO NOT EDIT*`` prefix is not injected); the ordering/type
+converters for scopes, bindings, and schedule continue to run on both the
+constructor and ``from_api`` paths.
+"""
+
+import pytest
+
+from tcadmin.resources.client import Client
+from tcadmin.resources.role import Role
+from tcadmin.resources.hook import Hook, Binding
+from tcadmin.resources.worker_pool import WorkerPool
+from tcadmin.resources.secret import Secret
+
+
+pytestmark = pytest.mark.usefixtures("appconfig")
+
+
+# --- Client ------------------------------------------------------------------
+
+def test_client_from_api_preserves_raw_description():
+    "from_api preserves the API description as-is, without prepending a prefix"
+    api_result = {
+        "clientId": "cid",
+        "description": "raw description without prefix",
+        "scopes": ["scope-a"],
+    }
+    client = Client.from_api(api_result)
+    assert client.description == "raw description without prefix"
+
+
+def test_client_from_api_preserves_empty_description():
+    "from_api preserves an empty API description as empty (does not inject prefix)"
+    api_result = {
+        "clientId": "cid",
+        "description": "",
+        "scopes": [],
+    }
+    client = Client.from_api(api_result)
+    assert client.description == ""
+
+
+def test_client_from_api_sorts_scopes():
+    "from_api still applies scopes_converter (sort + tuple)"
+    api_result = {
+        "clientId": "cid",
+        "description": "*DO NOT EDIT* - desc",
+        "scopes": ["c", "a", "b"],
+    }
+    client = Client.from_api(api_result)
+    assert client.scopes == ("a", "b", "c")
+    assert isinstance(client.scopes, tuple)
+
+
+def test_client_constructor_still_runs_converters():
+    "Constructing a Client directly (e.g. from YAML) still runs converters"
+    client = Client(clientId="cid", description="user-supplied", scopes=["c", "a"])
+    assert client.description.startswith("*DO NOT EDIT*")
+    assert client.description.endswith("user-supplied")
+    assert client.scopes == ("a", "c")
+
+
+# --- Role --------------------------------------------------------------------
+
+def test_role_from_api_preserves_raw_description():
+    api_result = {
+        "roleId": "rid",
+        "description": "raw description without prefix",
+        "scopes": ["scope-a"],
+    }
+    role = Role.from_api(api_result)
+    assert role.description == "raw description without prefix"
+
+
+def test_role_from_api_sorts_scopes():
+    api_result = {
+        "roleId": "rid",
+        "description": "*DO NOT EDIT* - desc",
+        "scopes": ["z", "a", "m"],
+    }
+    role = Role.from_api(api_result)
+    assert role.scopes == ("a", "m", "z")
+    assert isinstance(role.scopes, tuple)
+
+
+def test_role_constructor_still_runs_converters():
+    role = Role(roleId="rid", description="user-supplied", scopes=["c", "a"])
+    assert role.description.startswith("*DO NOT EDIT*")
+    assert role.description.endswith("user-supplied")
+    assert role.scopes == ("a", "c")
+
+
+# --- Hook --------------------------------------------------------------------
+
+def _hook_api_result(**overrides):
+    base = {
+        "hookGroupId": "g",
+        "hookId": "h",
+        "metadata": {
+            "name": "n",
+            "description": "raw description without prefix",
+            "owner": "o@e.com",
+            "emailOnError": False,
+        },
+        "schedule": ["0 0 * * * *"],
+        "task": {"$magic": "task"},
+        "triggerSchema": {},
+        "bindings": [
+            {"exchange": "z-exchange", "routingKeyPattern": "rkp"},
+            {"exchange": "a-exchange", "routingKeyPattern": "rkp"},
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_hook_from_api_preserves_raw_description():
+    hook = Hook.from_api(_hook_api_result())
+    assert hook.description == "raw description without prefix"
+
+
+def test_hook_from_api_sorts_bindings():
+    "from_api still applies bindings_converter (sort + tuple)"
+    hook = Hook.from_api(_hook_api_result())
+    assert hook.bindings == (
+        Binding(exchange="a-exchange", routingKeyPattern="rkp"),
+        Binding(exchange="z-exchange", routingKeyPattern="rkp"),
+    )
+    assert isinstance(hook.bindings, tuple)
+
+
+def test_hook_from_api_schedule_is_tuple():
+    "from_api still applies schedule_converter (list → tuple)"
+    hook = Hook.from_api(_hook_api_result())
+    assert isinstance(hook.schedule, tuple)
+    assert hook.schedule == ("0 0 * * * *",)
+
+
+def test_hook_constructor_still_runs_converters():
+    "Constructing a Hook directly still applies description prefix and sorts bindings"
+    hook = Hook(
+        hookGroupId="g",
+        hookId="h",
+        name="n",
+        description="user-supplied",
+        owner="o@e.com",
+        emailOnError=False,
+        schedule=["0 0 * * * *"],
+        bindings=[
+            Binding(exchange="z", routingKeyPattern="rkp"),
+            Binding(exchange="a", routingKeyPattern="rkp"),
+        ],
+        task={},
+        triggerSchema={},
+    )
+    assert hook.description.startswith("*DO NOT EDIT*")
+    assert hook.description.endswith("user-supplied")
+    assert hook.bindings[0].exchange == "a"
+    assert hook.bindings[1].exchange == "z"
+    assert isinstance(hook.schedule, tuple)
+
+
+# --- WorkerPool --------------------------------------------------------------
+
+def test_worker_pool_from_api_preserves_raw_description():
+    api_result = {
+        "config": {"is": "config"},
+        "workerPoolId": "p/w",
+        "description": "raw description without prefix",
+        "owner": "o@e.com",
+        "emailOnError": False,
+        "providerId": "static",
+    }
+    wp = WorkerPool.from_api(api_result)
+    assert wp.description == "raw description without prefix"
+
+
+def test_worker_pool_constructor_still_runs_converters():
+    wp = WorkerPool(
+        workerPoolId="p/w",
+        description="user-supplied",
+        owner="o@e.com",
+        config={},
+        emailOnError=False,
+        providerId="static",
+    )
+    assert wp.description.startswith("*DO NOT EDIT*")
+    assert wp.description.endswith("user-supplied")
+
+
+# --- Secret (no field-level converters; verify behaviour unchanged) ---------
+
+def test_secret_from_api_unchanged():
+    api_result = {"secret": {"k": "v"}}
+    secret = Secret.from_api("my-secret", api_result)
+    assert secret.name == "my-secret"
+    assert secret.secret == {"k": "v"}

--- a/tcadmin/tests/test_resources_worker_pool.py
+++ b/tcadmin/tests/test_resources_worker_pool.py
@@ -70,12 +70,10 @@ def test_role_from_api():
         "is": "config",
         "launchConfigs": [{"zone": "a"}, {"zone": "b"}],
     }
-    assert apwt.description == textwrap.dedent(
-        """\
-            *DO NOT EDIT* - This resource is configured automatically.
-
-            descr"""
-    )
+    # from_api preserves the API description verbatim, without prepending the
+    # *DO NOT EDIT* prefix; that prefix is only applied to user-supplied input
+    # via the regular Resource constructor.
+    assert apwt.description == "descr"
     assert apwt.owner == "owner"
     assert apwt.emailOnError is True
     assert apwt.providerId == "cirrus"


### PR DESCRIPTION
`description_converter` prepends [`AppConfig.description_prefix`](https://github.com/mozilla-releng/fxci-config/blob/909ca30e02f2240c5e7cf2360e7e8633eadfcce1/src/ciadmin/boot.py#L50-L53) (`*DO NOT EDIT* - …`) to every Resource's `description`. It runs in the auto-generated `__init__`, which means it also runs in `Resource.from_api(api_result)`. So if the live API stores a description that's missing the prefix, `from_api` silently injects it in memory; the in-memory current-state object then matches the desired-state object, `Updater.update`'s `c == g` check returns True, and `tc-admin apply` skips the update — forever.

This PR fixes that. Each `from_api` now constructs the Resource through a new `Resource._construct_without_converters` helper that bypasses `attrs`-generated `__init__`, then explicitly pre-applies only the ordering/type converters (`scopes_converter`, `bindings_converter`, `schedule_converter`). Those still need to run on API data — scope and binding order is semantically irrelevant, and skipping them would create permanent spurious diffs against the server's ordering. Only `description_converter` mutates a semantically meaningful value, and it's the one we drop on the `from_api` path.

The regular constructor — used by YAML loaders and any other generator — still runs every converter as before. No public-API change for code outside `from_api`.

After this lands, `tc-admin apply` will reconcile resources whose live description is missing the prefix. Operators should expect a one-time wave of description-only updates on their next apply run.

## Example: descriptions that will be reconciled in fxci-config

The following 22 Clients in Mozilla's [fxci-config](https://github.com/mozilla-releng/fxci-config) are managed by tc-admin and currently store a description in the live API that is missing the configured prefix. With this PR, the next `tc-admin apply` run will update each of them to include it. Other tc-admin deployments may have their own affected entities depending on how the live state has diverged.

| Client | Current live description |
|--------|--------------------------|
| [`project/autophone/gecko-t-bitbar-batt-g5`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Fautophone%2Fgecko-t-bitbar-batt-g5) | _(empty)_ |
| [`project/autophone/gecko-t-bitbar-batt-p2`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Fautophone%2Fgecko-t-bitbar-batt-p2) | _(empty)_ |
| [`project/autophone/gecko-t-bitbar-perf-g5`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Fautophone%2Fgecko-t-bitbar-perf-g5) | _(empty)_ |
| [`project/autophone/gecko-t-bitbar-perf-p2`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Fautophone%2Fgecko-t-bitbar-perf-p2) | _(empty)_ |
| [`project/autophone/gecko-t-bitbar-unit-g5`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Fautophone%2Fgecko-t-bitbar-unit-g5) | _(empty)_ |
| [`project/autophone/gecko-t-bitbar-unit-p2`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Fautophone%2Fgecko-t-bitbar-unit-p2) | _(empty)_ |
| [`project/packet/docker-worker`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Fpacket%2Fdocker-worker) | _(empty)_ |
| [`project/taskcluster/legacy-login`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Ftaskcluster%2Flegacy-login) | _(empty)_ |
| [`project/releng/generic-worker/azure-gecko-t-win10-64`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Freleng%2Fgeneric-worker%2Fazure-gecko-t-win10-64) | Windows 10 64bit experimental production worker. |
| [`project/releng/generic-worker/azure-gecko-t-win10-64-gpu`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Freleng%2Fgeneric-worker%2Fazure-gecko-t-win10-64-gpu) | Windows 10 64bit GPU experimental production worker. |
| [`project/releng/generic-worker/bitbar-gecko-t-win10-64-ref-18`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Freleng%2Fgeneric-worker%2Fbitbar-gecko-t-win10-64-ref-18) | Windows 10 2018 reference laptop production worker. Hardware hosted by Bitbar |
| [`project/releng/generic-worker/bitbar-gecko-t-win10-64-ref-18t`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Freleng%2Fgeneric-worker%2Fbitbar-gecko-t-win10-64-ref-18t) | Windows 10 2018 reference laptop testing worker. Hardware hosted by Bitbar |
| [`project/releng/generic-worker/bitbar-gecko-t-win10-64-ref-hw`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Freleng%2Fgeneric-worker%2Fbitbar-gecko-t-win10-64-ref-hw) | Windows 10 2017 reference laptop production worker. Hardware hosted by Bitbar |
| [`project/releng/generic-worker/bitbar-gecko-t-win10-aarch64`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Freleng%2Fgeneric-worker%2Fbitbar-gecko-t-win10-aarch64) | Windows 10 aarch64 YogaC630 production worker. Hardware hosted by Bitbar |
| [`project/releng/generic-worker/datacenter-gecko-3-t-osx`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Freleng%2Fgeneric-worker%2Fdatacenter-gecko-3-t-osx) | Datacenter level 3 MacOS dedicated developer and automation worker. |
| [`project/releng/generic-worker/datacenter-gecko-t-linux-beta`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Freleng%2Fgeneric-worker%2Fdatacenter-gecko-t-linux-beta) | testing non-perf tasks on linux hardware workers |
| [`project/releng/generic-worker/datacenter-gecko-t-linux-staging`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Freleng%2Fgeneric-worker%2Fdatacenter-gecko-t-linux-staging) | Datacenter Linux64 dedicated developer and automation staging worker. |
| [`project/releng/quarantine-worker`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Freleng%2Fquarantine-worker) | Self-quarantine access for hardware workers after generic-worker fails with code 69. |
| [`project/releng/services/tooltool/bug1604706`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Freleng%2Fservices%2Ftooltool%2Fbug1604706) | tooltool permissions for occ |
| [`project/relman/code-review/backend-production`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Frelman%2Fcode-review%2Fbackend-production) | See [bug 1593749](https://bugzilla.mozilla.org/show_bug.cgi?id=1593749#c12) |
| [`project/relman/code-review/backend-testing`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Frelman%2Fcode-review%2Fbackend-testing) | See [bug 1593749](https://bugzilla.mozilla.org/show_bug.cgi?id=1593749#c12) |
| [`project/wpt/wptsync`](https://firefox-ci-tc.services.mozilla.com/auth/clients/project%2Fwpt%2Fwptsync) | Created in Bug 1596469 - Secret handed to :jgraham |
