### PR TITLE
fix: pickling of slotted Resource subclasses

### DIFF
--- a/tcadmin/resources/resources.py
+++ b/tcadmin/resources/resources.py
@@ -18,7 +18,7 @@ t = blessings.Terminal()
 
 
 @functools.total_ordering
-@attr.s(slots=True, frozen=True)
+@attr.s(slots=True, frozen=True, getstate_setstate=False)
 class Resource(object):
     """
     Base class for a single runtime configuration resource

--- a/tcadmin/tests/test_resources_hook.py
+++ b/tcadmin/tests/test_resources_hook.py
@@ -4,6 +4,8 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 
+import pickle
+
 import pytest
 import textwrap
 
@@ -59,8 +61,16 @@ def test_hook_formatter(simple_hook):
     )
 
 
+def test_hook_pickle_roundtrip(simple_hook):
+    "Pickling a Hook round-trips"
+    unpickled = pickle.loads(pickle.dumps(simple_hook))
+    assert unpickled == simple_hook
+    assert unpickled.bindings == simple_hook.bindings
+    assert all(isinstance(b, Binding) for b in unpickled.bindings)
+
+
 def test_role_from_api():
-    "HOoks are properly read from a Taskcluster API result"
+    "Hooks are properly read from a Taskcluster API result"
     api_result = {
         "hookGroupId": "garbage",
         "hookId": "test",

--- a/tcadmin/tests/test_resources_resources.py
+++ b/tcadmin/tests/test_resources_resources.py
@@ -5,6 +5,8 @@
 # obtain one at http://mozilla.org/MPL/2.0/.
 
 import json
+import pickle
+
 import attr
 import pytest
 import textwrap
@@ -93,6 +95,15 @@ def test_resource_id_immutable():
     a = Thing("a", "V")
     with pytest.raises(Exception):
         a.id = "b"
+
+
+def test_resource_pickle_roundtrip():
+    "Resource subclasses must pickle correctly"
+    a = Thing("a", "V")
+    unpickled = pickle.loads(pickle.dumps(a))
+    assert unpickled == a
+    assert unpickled.thingId == "a"
+    assert unpickled.value == "V"
 
 
 def test_resource_str():


### PR DESCRIPTION
Resource is slots=True, frozen=True, which made attrs generate custom __getstate__/__setstate__ functions that breaks pickling for subclasses with non-slotted state (e.g. Hook's nested Binding attrs).