### PR TITLE
feat: allow merging roles with different descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,20 +413,23 @@ role = Role(
     scopes=(.., ..))
 ```
 
-As with hooks, `scopes` must be a tuple (not a list) of strings.
+As with hooks, `scopes` must be a tuple (not a list) of strings. The `description` is optional.
 
-Roles can be merged if their descriptions match.
+Roles with the same `roleId` are merged automatically.
 The resulting role contains the union of the scopes of the input roles.
 This functionality makes management of roles easier in cases where different parts of the generation process may add scopes to the same role.
+
+Descriptions do not need to match to merge. If only one side has a description that description is used, otherwise the first role's
+description wins.
 
 For example:
 
 ```python
 resources.add(Role(roleId="my-role", description="My Role", scopes=["scope1"]))
-resources.add(Role(roleId="my-role", description="My Role", scopes=["scope2"]))
+resources.add(Role(roleId="my-role", scopes=["scope2"]))
 ```
 
-This will result in a single Role with scopes `["scope1", "scope2"]`.
+This will result in a single Role with description `"My Role"` and scopes `["scope1", "scope2"]`.
 
 ### Client
 

--- a/tcadmin/resources/client.py
+++ b/tcadmin/resources/client.py
@@ -8,7 +8,7 @@ import attr
 import datetime
 
 from .resources import Resource
-from .util import description_converter, scopes_converter, list_formatter
+from .util import Description, description_converter, scopes_converter, list_formatter
 from ..util.scopes import normalizeScopes
 
 FOREVER = datetime.datetime(3000, 1, 1, 0, 0, 0)
@@ -17,9 +17,12 @@ FOREVER = datetime.datetime(3000, 1, 1, 0, 0, 0)
 @attr.s
 class Client(Resource):
     clientId = attr.ib(type=str)
-    description = attr.ib(type=str, converter=description_converter)
+    description = attr.ib(type=Description, default="", converter=description_converter)
     scopes = attr.ib(
-        type=tuple, converter=scopes_converter, metadata={"formatter": list_formatter}
+        type=tuple,
+        default=(),
+        converter=scopes_converter,
+        metadata={"formatter": list_formatter},
     )
 
     # NOTE: clients are managed like roles.  Any associated access tokens are
@@ -47,11 +50,6 @@ class Client(Resource):
 
     def merge(self, other):
         assert self.clientId == other.clientId
-        if self.description != other.description:
-            raise RuntimeError(
-                "Descriptions for {} to be merged differ".format(self.id)
-            )
+        description = self.description if self.description.has_content else other.description
         scopes = normalizeScopes(self.scopes + other.scopes)
-        return Client(
-            clientId=self.clientId, description=self.description, scopes=scopes
-        )
+        return Client(clientId=self.clientId, description=description, scopes=scopes)

--- a/tcadmin/resources/role.py
+++ b/tcadmin/resources/role.py
@@ -7,16 +7,19 @@
 import attr
 
 from .resources import Resource
-from .util import description_converter, scopes_converter, list_formatter
+from .util import Description, description_converter, scopes_converter, list_formatter
 from ..util.scopes import normalizeScopes
 
 
 @attr.s
 class Role(Resource):
     roleId = attr.ib(type=str)
-    description = attr.ib(type=str, converter=description_converter)
+    description = attr.ib(type=Description, default="", converter=description_converter)
     scopes = attr.ib(
-        type=tuple, converter=scopes_converter, metadata={"formatter": list_formatter}
+        type=tuple,
+        default=(),
+        converter=scopes_converter,
+        metadata={"formatter": list_formatter},
     )
 
     @classmethod
@@ -33,10 +36,14 @@ class Role(Resource):
         return {"description": self.description, "scopes": self.scopes}
 
     def merge(self, other):
+        """
+        Merge with another Role for the same roleId, unioning scopes.
+
+        If only one side has a description, that description is used. If
+        both sides have a description, the one on `self` (the left/existing
+        side) wins.
+        """
         assert self.roleId == other.roleId
-        if self.description != other.description:
-            raise RuntimeError(
-                "Descriptions for {} to be merged differ".format(self.id)
-            )
+        description = self.description if self.description.has_content else other.description
         scopes = normalizeScopes(self.scopes + other.scopes)
-        return Role(roleId=self.roleId, description=self.description, scopes=scopes)
+        return Role(roleId=self.roleId, description=description, scopes=scopes)

--- a/tcadmin/resources/util.py
+++ b/tcadmin/resources/util.py
@@ -7,14 +7,28 @@
 from ..util.json import pretty_json
 
 
+class Description(str):
+    """A description string that remembers whether the value it was built
+    from (before the boilerplate prefix was added) had any real content.
+    """
+
+    def __new__(cls, value, has_content):
+        self = str.__new__(cls, value)
+        self.has_content = has_content
+        return self
+
+
 def description_converter(value):
     """Prepend *DO NOT EDIT* and a short explainer to the given value"""
     from ..appconfig import AppConfig
 
+    has_content = (
+        value.has_content if isinstance(value, Description) else bool(value)
+    )
     description_prefix = AppConfig.current().description_prefix
     if not value.startswith(description_prefix):
         value = description_prefix + value
-    return value
+    return Description(value, has_content)
 
 
 def scopes_converter(value):

--- a/tcadmin/tests/test_resources_client.py
+++ b/tcadmin/tests/test_resources_client.py
@@ -78,9 +78,38 @@ def test_client_merge_normalized():
 
 
 def test_client_merge_different_descr():
-    "Descriptions must match to merge"
+    "When both sides have a description, the left (self) side wins"
     r1 = Client(clientId="client", description="test1", scopes=["a"])
     r2 = Client(clientId="client", description="test2", scopes=["b"])
-    with pytest.raises(RuntimeError) as exc:
-        r1.merge(r2)
-    assert "Descriptions for Client=client to be merged differ" in str(exc.value)
+    merged = r1.merge(r2)
+    assert merged.description.endswith("test1")
+    assert merged.scopes == ("a", "b")
+
+
+def test_client_merge_missing_description_uses_other_side():
+    "If only one side has a description, that description is used"
+    with_descr = Client(clientId="client", description="test", scopes=["a"])
+    without_descr = Client(clientId="client", scopes=["b"])
+
+    merged = without_descr.merge(with_descr)
+    assert merged.description.endswith("test")
+    assert merged.scopes == ("a", "b")
+
+    merged = with_descr.merge(without_descr)
+    assert merged.description.endswith("test")
+    assert merged.scopes == ("a", "b")
+
+
+def test_client_merge_neither_has_description(appconfig):
+    "If neither side has a description, the merged client has none either"
+    r1 = Client(clientId="client", scopes=["a"])
+    r2 = Client(clientId="client", scopes=["b"])
+    merged = r1.merge(r2)
+    assert merged.description == appconfig.description_prefix
+    assert merged.scopes == ("a", "b")
+
+
+def test_client_description_is_optional(appconfig):
+    "A client can be constructed without a description at all"
+    client = Client(clientId="client", scopes=["a"])
+    assert client.description == appconfig.description_prefix

--- a/tcadmin/tests/test_resources_role.py
+++ b/tcadmin/tests/test_resources_role.py
@@ -78,9 +78,38 @@ def test_role_merge_normalized():
 
 
 def test_role_merge_different_descr():
-    "Descriptions must match to merge"
+    "When both sides have a description, the left (self) side wins"
     r1 = Role(roleId="role", description="test1", scopes=["a"])
     r2 = Role(roleId="role", description="test2", scopes=["b"])
-    with pytest.raises(RuntimeError) as exc:
-        r1.merge(r2)
-    assert "Descriptions for Role=role to be merged differ" in str(exc.value)
+    merged = r1.merge(r2)
+    assert merged.description.endswith("test1")
+    assert merged.scopes == ("a", "b")
+
+
+def test_role_merge_missing_description_uses_other_side():
+    "If only one side has a description, that description is used"
+    with_descr = Role(roleId="role", description="test", scopes=["a"])
+    without_descr = Role(roleId="role", scopes=["b"])
+
+    merged = without_descr.merge(with_descr)
+    assert merged.description.endswith("test")
+    assert merged.scopes == ("a", "b")
+
+    merged = with_descr.merge(without_descr)
+    assert merged.description.endswith("test")
+    assert merged.scopes == ("a", "b")
+
+
+def test_role_merge_neither_has_description(appconfig):
+    "If neither side has a description, the merged role has none either"
+    r1 = Role(roleId="role", scopes=["a"])
+    r2 = Role(roleId="role", scopes=["b"])
+    merged = r1.merge(r2)
+    assert merged.description == appconfig.description_prefix
+    assert merged.scopes == ("a", "b")
+
+
+def test_role_description_is_optional(appconfig):
+    "A role can be constructed without a description at all"
+    role = Role(roleId="role", scopes=["a"])
+    assert role.description == appconfig.description_prefix

--- a/tcadmin/tests/test_util_description_converter.py
+++ b/tcadmin/tests/test_util_description_converter.py
@@ -25,3 +25,32 @@ def test_description_converter_idempotent(appconfig):
     descr = description_converter(descr)
     print(descr)
     assert descr == "I AM A PREFIX\n\nI am a description"
+
+
+def test_description_converter_empty_string(appconfig):
+    "An empty description results in just the prefix, and has_content is False"
+    appconfig.description_prefix = "I AM A PREFIX\n\n"
+    descr = description_converter("")
+    assert descr == "I AM A PREFIX\n\n"
+    assert descr.has_content is False
+
+
+def test_description_converter_has_content(appconfig):
+    "A real description has has_content set to True"
+    appconfig.description_prefix = "I AM A PREFIX\n\n"
+    descr = description_converter("I am a description")
+    assert descr.has_content is True
+
+
+def test_description_converter_has_content_survives_reconversion(appconfig):
+    "has_content is preserved when an already-converted description is re-converted"
+    appconfig.description_prefix = "I AM A PREFIX\n\n"
+    empty = description_converter("")
+    assert empty.has_content is False
+    # re-converting an already-prefixed (and thus non-empty) string must not
+    # flip has_content to True just because the string itself is now truthy
+    assert description_converter(empty).has_content is False
+
+    real = description_converter("I am a description")
+    assert real.has_content is True
+    assert description_converter(real).has_content is True


### PR DESCRIPTION
In fxci-config we have clients that can come from two files:
- clients.yml (static)
- clients-interpreted.yml (dynamically generated)

In some cases it would be useful for me to define some scopes statically and others dynamically (both for the same client id). But the requirement that the descriptions must match is making this very annoying to implement.

Figured there's not really a good reason to enforce this, so it would be simplest to remove that requirement.